### PR TITLE
feat(cache-stampede): added basic support for cache stampede prevention

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -78,6 +78,7 @@ stages:
               versioningScheme: 'off'
           - task: CmdLine@2
             displayName: Push
+            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
             inputs:
               script: 'dotnet nuget push *.nupkg --api-key $(nugetApiKey) --source https://api.nuget.org/v3/index.json --skip-duplicate'
               workingDirectory: '$(Build.ArtifactStagingDirectory)'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.2.0</Version>
+    <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <WeaverConfiguration>
       <Weavers>

--- a/src/TwoTierCache.Abstractions/CacheResult.cs
+++ b/src/TwoTierCache.Abstractions/CacheResult.cs
@@ -1,0 +1,17 @@
+namespace TwoTierCache.Abstractions;
+
+public readonly struct CacheResult<T>
+{
+    public CacheResult(T? value)
+    {
+        Value = value;
+        Success = true;
+    }
+    
+    public T? Value { get; }
+    
+    public bool Success { get; }
+
+    public static CacheResult<T> Miss => new();
+    public static CacheResult<T> Found(T? value) => new(value);
+}

--- a/src/TwoTierCache.Abstractions/ITwoTierCache.cs
+++ b/src/TwoTierCache.Abstractions/ITwoTierCache.cs
@@ -30,6 +30,26 @@ public interface ITwoTierCache
     ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Tries to get a value with the given key from the cache.
+    /// </summary>
+    /// <param name="key">A string identifying the requested value.</param>
+    /// <param name="cancellationToken">Optional. The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+    /// <typeparam name="T">The type of the value to retrieve.</typeparam>
+    /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing an <see cref="CacheResult{T}"/>.</returns>
+    ValueTask<CacheResult<T>> TryGetAsync<T>(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a value with the given key from the cache and, if not found, creates an entry in all cache tiers using the specified value factory.
+    /// </summary>
+    /// <param name="key">A string identifying the value.</param>
+    /// <param name="asyncValueFactory">The function which will be called if the value is not found in the cache.</param>
+    /// <param name="cancellationToken">Optional. The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+    /// <typeparam name="T">The type of the value to set in the cache.</typeparam>
+    /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+    Task<T?> GetOrCreateAsync<T>(string key, Func<TwoTierCacheEntryOptions, Task<T>> asyncValueFactory,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Removes the value with the given key from all cache tiers.
     /// </summary>
     /// <param name="key">A string identifying the requested value.</param>

--- a/src/TwoTierCache.AspNetCore.TicketStore/TwoTierCacheTicketStore.cs
+++ b/src/TwoTierCache.AspNetCore.TicketStore/TwoTierCacheTicketStore.cs
@@ -40,7 +40,8 @@ public class TwoTierCacheTicketStore : ITicketStore
     
     public async Task<AuthenticationTicket?> RetrieveAsync(string key, CancellationToken cancellationToken)
     {
-        return await _cache.GetAsync<AuthenticationTicket>(key, cancellationToken);
+        var result = await _cache.TryGetAsync<AuthenticationTicket>(key, cancellationToken);
+        return result.Success ? result.Value : null;
     }
 
     public Task RemoveAsync(string key) => RemoveAsync(key, default);

--- a/src/TwoTierCache/DefaultTwoTierCache.cs
+++ b/src/TwoTierCache/DefaultTwoTierCache.cs
@@ -15,6 +15,8 @@ public class DefaultTwoTierCache : ITwoTierCache
     private readonly IMemoryCache _memoryCache;
     private readonly IList<IDistributedCacheEntrySerializer> _serializers;
 
+    private readonly LazyOperationTracker _lazyOperationTracker = new LazyOperationTracker();
+
     public DefaultTwoTierCache(IDistributedCache distributedCache, IMemoryCache memoryCache,
         IEnumerable<IDistributedCacheEntrySerializer> serializers)
     {
@@ -30,6 +32,7 @@ public class DefaultTwoTierCache : ITwoTierCache
         _serializers = orderedSerializers;
     }
 
+    /// <inheritdoc/>
     public async ValueTask SetAsync<T>(string key, T value, TwoTierCacheEntryOptions options,
         CancellationToken cancellationToken = default)
     {
@@ -43,28 +46,58 @@ public class DefaultTwoTierCache : ITwoTierCache
         EntrySet?.Invoke(this, new TwoTierCacheEntrySetEventArgs(key, value));
     }
 
+    /// <inheritdoc/>
     public async ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
     {
-        if (_memoryCache.TryGetValue(key, out var result))
-        {
-            return (T)result;
-        }
+        var result = await TryGetInternalAsync<T>(key, cancellationToken);
 
-        var bytes = await _distributedCache.GetAsync(key, cancellationToken);
-
-        if (bytes is null)
-        {
-            return default;
-        }
-
-        var entry = Deserialize<T>(bytes);
-
-        _memoryCache.Set(key, entry.Value,
-            new MemoryCacheEntryOptions { AbsoluteExpiration = entry.Options?.AbsoluteExpiration });
-
-        return entry.Value;
+        return result.Success ? result.Value : default;
     }
 
+    /// <inheritdoc/>
+    public ValueTask<CacheResult<T>> TryGetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        return TryGetInternalAsync<T>(key, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<T?> GetOrCreateAsync<T>(string key, Func<TwoTierCacheEntryOptions, Task<T>> asyncValueFactory,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await TryGetInternalAsync<T>(key, cancellationToken);
+
+        if (result.Success)
+        {
+            return result.Value;
+        }
+
+        try
+        {
+            return await _lazyOperationTracker.GetOrAddOperation(key, async cacheKey =>
+            {
+                var getResult = await TryGetInternalAsync<T>(key, CancellationToken.None);
+                
+                if (getResult.Success)
+                {
+                    return getResult.Value;
+                }
+                
+                var entryOptions = new TwoTierCacheEntryOptions();
+                
+                var createdValue = await asyncValueFactory.Invoke(entryOptions).ConfigureAwait(false);
+                
+                await SetAsync(cacheKey, createdValue, entryOptions, CancellationToken.None);
+                
+                return createdValue;
+            });
+        }
+        finally
+        {
+            _lazyOperationTracker.RemoveOperation(key);
+        }
+    }
+
+    /// <inheritdoc/>
     public async ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default)
     {
         _memoryCache.Remove(key);
@@ -72,12 +105,49 @@ public class DefaultTwoTierCache : ITwoTierCache
         EntryRemoved?.Invoke(this, new TwoTierCacheEntryRemovedEventArgs(key));
     }
 
+    /// <inheritdoc/>
     public void EvictLocal(string key)
     {
         _memoryCache.Remove(key);
     }
 
-    private byte[] Serialize<T>(T value, TwoTierCacheEntryOptions options)
+    private async ValueTask<CacheResult<T>> TryGetInternalAsync<T>(string key, CancellationToken cancellationToken)
+    {
+        if (_memoryCache.TryGetValue(key, out var result))
+        {
+            return CacheResult<T>.Found((T) result);
+        }
+
+        var bytes = await _distributedCache.GetAsync(key, cancellationToken);
+        
+        // IDistributedCache does not expose a way to understand if a key
+        // was present or not in the cache, but we can try to infer this by the result
+        // if the result is null, we infer that there was no key, while if an explicit null
+        // was set on the distributed cache, the byte array value would not be null itself
+        // but be a representation of the null value for the serializer
+
+        if (bytes is null)
+        {
+            return CacheResult<T>.Miss;
+        }
+
+        var entry = Deserialize<T>(bytes);
+
+        _memoryCache.Set(key, entry.Value,
+            new MemoryCacheEntryOptions {AbsoluteExpiration = entry.Options?.AbsoluteExpiration});
+
+        return CacheResult<T>.Found(entry.Value);
+    }
+
+    /// <summary>
+    /// Serializes value and cache options with the best fitting serializer, if any.
+    /// </summary>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="options">The options to serialize</param>
+    /// <typeparam name="T">Type of the value</typeparam>
+    /// <returns>Binary data of serialized value and options</returns>
+    /// <exception cref="NotSupportedException">If no serializer is found that can serialize <see cref="T"/></exception>
+    private byte[] Serialize<T>(T? value, TwoTierCacheEntryOptions options)
     {
         var serializer = _serializers.FirstOrDefault(s => s.CanSerialize(typeof(T)));
 
@@ -89,6 +159,13 @@ public class DefaultTwoTierCache : ITwoTierCache
         return serializer.Serialize(new DistributedCacheEntry<T> { Value = value, Options = options });
     }
 
+    /// <summary>
+    /// Deserializes binary data into value and cache options with the best fitting serializer, if any.
+    /// </summary>
+    /// <param name="bytes">Binary serialized data.</param>
+    /// <typeparam name="T">Type of the value</typeparam>
+    /// <returns>A <see cref="DistributedCacheEntry{T}"/> containing the original value and options</returns>
+    /// <exception cref="NotSupportedException">If no serializer is found that can serialize <see cref="T"/></exception>
     private DistributedCacheEntry<T> Deserialize<T>(byte[] bytes)
     {
         var serializer = _serializers.FirstOrDefault(s => s.CanSerialize(typeof(T)));
@@ -101,6 +178,9 @@ public class DefaultTwoTierCache : ITwoTierCache
         return serializer.Deserialize<T>(bytes);
     }
 
+    /// <inheritdoc/>
     public event EventHandler<TwoTierCacheEntrySetEventArgs>? EntrySet;
+
+    /// <inheritdoc/>
     public event EventHandler<TwoTierCacheEntryRemovedEventArgs>? EntryRemoved;
 }

--- a/src/TwoTierCache/LazyOperationTracker.cs
+++ b/src/TwoTierCache/LazyOperationTracker.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Concurrent;
+
+namespace TwoTierCache;
+
+/// <summary>
+/// Tracks concurrent async operations so the caller reuses the same task when
+/// called in parallel 
+/// </summary>
+internal class LazyOperationTracker
+{
+    private readonly ConcurrentDictionary<string, Lazy<object>> _runningOperations = new();
+
+    public void RemoveOperation(string key) => _runningOperations.TryRemove(key, out _);
+
+    public Task<T> GetOrAddOperation<T>(string key, Func<string, Task<T>> valueFactory)
+    {
+        var lazyOperation = _runningOperations.GetOrAdd(key, cacheKey =>
+        {
+            return new Lazy<object>(() => valueFactory.Invoke(cacheKey));
+        });
+
+        return (Task<T>)lazyOperation.Value;
+    }
+}

--- a/test/TwoTierCache.AspNetCore.TicketStore.Tests/TwoTierCacheTicketStoreTests.cs
+++ b/test/TwoTierCache.AspNetCore.TicketStore.Tests/TwoTierCacheTicketStoreTests.cs
@@ -66,8 +66,8 @@ public class TwoTierCacheTicketStoreTests
 
         var key = Guid.NewGuid().ToString();
 
-        _cache.GetAsync<AuthenticationTicket>(key, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<AuthenticationTicket?>(ticket));
+        _cache.TryGetAsync<AuthenticationTicket>(key, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<CacheResult<AuthenticationTicket?>>(new CacheResult<AuthenticationTicket?>(ticket)));
         
         // Act
         var retrievedTicket = await _store.RetrieveAsync(key);


### PR DESCRIPTION
Added basic cache stampede prevention with a new method `GetOrCreateAsync`. Also added a new method `TryGetAsync` to allow the caller to distinguish wheatear the entry was in the cache (but it was null) or it was not in the cache.